### PR TITLE
oneplus3: releasetools: Split up getting android-info.txt

### DIFF
--- a/releasetools.py
+++ b/releasetools.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2009 The Android Open Source Project
 # Copyright (c) 2011, The Linux Foundation. All rights reserved.
-# Copyright (C) 2017 The LineageOS Project
+# Copyright (C) 2017-2018 The LineageOS Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,15 +19,15 @@ import common
 import re
 
 def FullOTA_Assertions(info):
-  AddModemAssertion(info)
+  AddModemAssertion(info, info.input_zip)
   return
 
 def IncrementalOTA_Assertions(info):
-  AddModemAssertion(info)
+  AddModemAssertion(info, info.target_zip)
   return
 
-def AddModemAssertion(info):
-  android_info = info.input_zip.read("OTA/android-info.txt")
+def AddModemAssertion(info, input_zip):
+  android_info = input_zip.read("OTA/android-info.txt")
   m = re.search(r'require\s+version-modem\s*=\s*(.+)', android_info)
   if m:
     version = m.group(1).rstrip()


### PR DESCRIPTION
input_zip does not exist when generating an incremental
OTA, which results in an error when it tries to package
one. The correct replacement for that would be target_zip.

Split up the process of getting the device-specific
information by passing corresponding zip as a parameter to
AddModemAssertion()

Change-Id: Ib246658f71d9f30a0aa34e902a400ef108a3ed1f